### PR TITLE
fix NullPointerException, assume unknown OS is *nix with shared object.

### DIFF
--- a/common/src/main/java/dev/felnull/fnjl/os/OSs.java
+++ b/common/src/main/java/dev/felnull/fnjl/os/OSs.java
@@ -122,7 +122,7 @@ public class OSs {
     }
 
     public static enum Type {
-        WINDOWS("windows", "dll"), LINUX("linux", "so"), MAC("mac", "jnilib"), OTHER(null, null);
+        WINDOWS("windows", "dll"), LINUX("linux", "so"), MAC("mac", "jnilib"), OTHER("", "so");
         private final String name;
         private final String libName;
 


### PR DESCRIPTION
If the os reported by System.getProperty("os.name") is not one of the 3 that are expected, GetOS() will try to compare a string against NULL, throwing an uncaught exception. This is not the best fix, but it will at least prevent a NullPointerException.

I found this problem while trying to run this mod on OpenBSD 7.5 and having it crash due to this :3